### PR TITLE
Use htslib functions to test availability of B/CRAM index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build
 /dist
 .dep.inc
+.Rproj.user


### PR DESCRIPTION
This pull request switches the check for availability of the BAM index by using htslib functions. This enables the transparent use of any sequence alignment format and index htslib is able to use. In particular, it allows to process CRAM files.